### PR TITLE
Remove root restriction. It breaks Cromwell GCP in a weird way

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,4 @@ RUN pip3 install cnvkit==0.9.7.b1
 #RUN head `which cnvkit.py`
 RUN cnvkit.py version
 
-## USER CONFIGURATION, containers should not run as root
-RUN adduser --disabled-password --gecos '' ubuntu && chsh -s /bin/bash && mkdir -p /home/ubuntu
-USER    ubuntu
-WORKDIR /home/ubuntu
-
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 # original MAINTAINER Eric Talevich <eric.talevich@ucsf.edu>
 # this patch was created by https://github.com/keiranmraine
 # https://github.com/etal/cnvkit/pull/493


### PR DESCRIPTION
cnvkitBatch will reindex a .bam file if its .bai was created before
the .bam. Locally this isn't a problem but in GCP when the files are
localized, the .bai downloads first. According to cnvkit the solution
is to `touch` the .bai file. In the GCP VM created by Cromwell for
this task, however, permissions to do this are denied because
Cromwell's /cromwell_root/ directory requires root permissions to
write. cnvkit Docker image strips those away, preventing the `touch`
from working.

In version 0.9.5 the GCP instance happily creates the index, but in
0.9.7+ the script throws an error. We hoped to avoid this error by
avoiding the reindex, but were prevented by the permissions
issue. This should resolve that.

Also had to upgrade Ubuntu to 20.04 to get access to Python3.8 or the docker image wouldn't build on my machine? Not quite sure what that one is about